### PR TITLE
README should reference PORT not API_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ cd ./sgx-twilio && npm install
 | COMPONENT\_DOMAIN | Domain of the component this is, eg: 'twilio.sgx.domain.tld' |
 | COMPONENT\_SECRET | Component Secret / password to administer the xmpp component |
 | REDIS\_URL | redis instance to connect to ( or default redis if not present ) |
-| API\_PORT | port to host the web server for recieving messages ( default: 80 ) |
+| PORT | port to host the web server for recieving messages ( default: 80 ) |
 
 ```
-XMPP\_ADMIN= COMPONENT\_HOST= COMPONENT\_DOMAIN= COMPONENT\_SECRET= REDIS\_URL= API\_PORT= node server.js
+XMPP\_ADMIN= COMPONENT\_HOST= COMPONENT\_DOMAIN= COMPONENT\_SECRET= REDIS\_URL= PORT= node server.js
 ```
 
 


### PR DESCRIPTION
Since that is what the code already expects to be set, as is reasonable given
it's the standard env var for this anyway.